### PR TITLE
Only write persistent configuration when necessary 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- The `.appland` configuration file will only be written when necessary.
+- Updated instructions for running in CI/CD environments.
+
 ## [0.0.5]
 ### Added
 - `APPLAND_API_KEY` environment variable overrides all configuration.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # appland-cli
+[![Build Status](https://travis-ci.com/applandinc/appland.svg?token=oNqy5hPadVE4PUAF9ZWk&branch=master)](https://travis-ci.com/applandinc/appland)
 
 ## Usage
 ### Quickstart

--- a/README.md
+++ b/README.md
@@ -19,16 +19,12 @@ https://app.land/applications/5?mapset=13
 ```
 
 ### Running in CI/CD
-An API key can be provided to the `appland` CLI by specifying an environment
-variable in the `.appland.yml` file. Configure your CI/CD tool to provide the
-specified environment variable at runtime.
-```yml
-current_context: default
-contexts:
-  default:
-    url: https://app.land
-    api_key: $APPLAND_API_KEY
-```
+Configure your CI/CD tool to provide the following environment variables at
+runtime. By providing these environment variables, `appland` can authenticate
+without any persistent configuration.
+- `APPLAND_API_KEY`: Generate a new API key from your [account page](https://app.land/user) to populate this value.
+- `APPLAND_URL`: Typically this will always be set to `https://app.land`
+
 
 ### Commands
 #### authentication

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -69,22 +69,14 @@ Available variables:
 					context, err = config.GetContext(contextName)
 				} else {
 					context, err = config.GetCurrentContext()
-					contextName = config.GetCurrentContextName()
 				}
 
 				if err != nil {
 					fail(err)
 				}
 
-				switch key {
-				case "url":
-					context.URL = value
-				case "api_key":
-					context.APIKey = value
-				case "name":
-					config.RenameContext(contextName, value)
-				default:
-					fail(fmt.Errorf("unknown key '%s'", key))
+				if err := context.SetVariable(key, value); err != nil {
+					fail(err)
 				}
 
 				fmt.Printf("'%s' set for '%s'\n", key, contextName)

--- a/internal/config/cli_test.go
+++ b/internal/config/cli_test.go
@@ -29,6 +29,7 @@ func TestWriteCLIConfig(t *testing.T) {
 				APIKey: "MY_API_KEY",
 			},
 		},
+		dirty: true,
 	}
 
 	err := WriteCLIConfig()
@@ -77,4 +78,29 @@ func TestMakeContext(t *testing.T) {
 	require.Nil(t, err)
 
 	assert.Equal(t, context.GetURL(), "hostname.com")
+}
+
+func TestDontWriteWithoutDirtyFlag(t *testing.T) {
+	setFileSystem(afero.NewMemMapFs())
+	LoadCLIConfig()
+
+	assert.Nil(t, WriteCLIConfig())
+
+	exists, _ := afero.Exists(fs, configPath)
+	assert.False(t, exists)
+}
+
+func TestWriteWithDirtyFlag(t *testing.T) {
+	setFileSystem(afero.NewMemMapFs())
+	LoadCLIConfig()
+
+	context, err := GetCurrentContext()
+	require.Nil(t, err)
+
+	context.SetURL("http://example")
+
+	assert.Nil(t, WriteCLIConfig())
+
+	exists, _ := afero.Exists(fs, configPath)
+	assert.True(t, exists)
 }


### PR DESCRIPTION
Writing configuration on every run could cause issues when running in ephemeral or otherwise tightly restricted environments where configuration is likely to come from the environment. This changes the behavior such that configuration is only written after it has been changed.