### PR TITLE
Version is properly set during release build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,8 @@ builds:
 - binary: appland
   env:
   - CGO_ENABLED=0
+  ldflags:
+  - -s -w -X github.com/applandinc/appland-cli/internal/build.Version={{.Version}}
 archives:
 - replacements:
     darwin: Darwin


### PR DESCRIPTION
This should fix the version from being reported as "unknown":
```$
$ appland -v     
appland version unknown
```