### PR TITLE
Add a branch fallback flag to appland upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Git metadata collection should be more resilient in cases where `HEAD` is not
   a branch
+- Add a `--branch/-b` flag to `appland upload` which specifies a branch name
+  fallback if the branch name cannot be resolved from Git.
 
 ## [0.2.0]
 ### Changed

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -16,6 +16,7 @@ import (
 
 func init() {
 	var (
+		branch          string
 		environment     string
 		organization    string
 		version         string
@@ -83,7 +84,8 @@ func init() {
 					SetOrganization(organization).
 					SetVersion(version).
 					SetEnvironment(environment).
-					WithGitMetadata(git)
+					WithGitMetadata(git).
+					SetBranch(branch)
 
 				res, err := api.CreateMapSet(mapSet)
 				if err != nil {
@@ -106,6 +108,7 @@ func init() {
 
 	uploadCmd.Flags().BoolVar(&dontOpenBrowser, "no-open", false, "Do not open the browser after a successful upload")
 	uploadCmd.Flags().StringVarP(&organization, "org", "o", "", "Override the owning organization")
+	uploadCmd.Flags().StringVarP(&branch, "branch", "b", "", "Set the MapSet branch if it's otherwise unavailable from Git")
 	uploadCmd.Flags().StringVarP(&version, "version", "v", "", "Set the MapSet version")
 	uploadCmd.Flags().StringVarP(&environment, "environment", "e", "", "Set the MapSet environment")
 	rootCmd.AddCommand(uploadCmd)

--- a/internal/appland/client.go
+++ b/internal/appland/client.go
@@ -84,9 +84,20 @@ func (mapset *MapSet) SetOrganization(org string) *MapSet {
 	return mapset
 }
 
+func (mapset *MapSet) SetBranch(branch string) *MapSet {
+	if mapset.Branch != "" && mapset.Branch != branch {
+		fmt.Fprintf(os.Stderr, "warn: current branch differs from override (%s != %s)", mapset.Branch, branch)
+	}
+
+	mapset.Branch = branch
+	return mapset
+}
+
 func (mapset *MapSet) WithGitMetadata(git *metadata.GitMetadata) *MapSet {
-	mapset.Branch = git.Branch
-	mapset.Commit = git.Commit
+	if git != nil {
+		mapset.Branch = git.Branch
+		mapset.Commit = git.Commit
+	}
 	return mapset
 }
 


### PR DESCRIPTION
If branch refs are unavailable, this fallback can be used to specify the branch name.

```
$ appland upload -b my-feature-branch appmap/*.appmap.json
```