### PR TITLE
feat: upload mapsets to existing mapset

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -86,11 +86,6 @@ func NewUploadCommand(options *UploadOptions, metadataProviders []metadata.Provi
 
 			timing := util.NewTiming("total")
 
-			var mapsetId *uint64 = nil
-			if (cmd.Flags().Changed("mapset")) {
-				mapsetId = &options.mapsetId
-			}
-
 			for _, scenarioFile := range scenarioFiles {
 				fileTiming := timing.Start(scenarioFile)
 
@@ -136,7 +131,7 @@ func NewUploadCommand(options *UploadOptions, metadataProviders []metadata.Provi
 				}
 
 				fileTiming.Start("uploading")
-				resp, err := api.CreateScenario(application, mapsetId, bytes.NewReader(data))
+				resp, err := api.CreateScenario(application, options.mapsetId, bytes.NewReader(data))
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "warning, failed uploading %s: %s\n", scenarioFile, err)
 				} else {
@@ -165,8 +160,8 @@ func NewUploadCommand(options *UploadOptions, metadataProviders []metadata.Provi
 				}
 				return fmt.Errorf("The --branch or -b flag can only be provided when uploading appmaps from within a Git repository")
 			}
-			
-			if mapsetId == nil {
+
+			if options.mapsetId == 0 {
 				mapSet := appland.BuildMapSet(application, scenarioUUIDs).
 					SetVersion(options.version).
 					SetEnvironment(options.environment).

--- a/cmd/upload_test.go
+++ b/cmd/upload_test.go
@@ -45,8 +45,8 @@ func (m *MockClient) CreateMapSet(mapset *appland.MapSet) (*appland.CreateMapSet
 	return resp, args.Error(1)
 }
 
-func (m *MockClient) CreateScenario(app string, scenarioData io.Reader) (*appland.ScenarioResponse, error) {
-	args := m.Called(app, scenarioData)
+func (m *MockClient) CreateScenario(app string, mapsetId *uint64, scenarioData io.Reader) (*appland.ScenarioResponse, error) {
+	args := m.Called(app, mapsetId, scenarioData)
 	resp, _ := args.Get(0).(*appland.ScenarioResponse)
 	return resp, args.Error(1)
 }
@@ -74,7 +74,7 @@ func TestUploadSingleAppMap(t *testing.T) {
 	api = mockClient
 
 	mockClient.
-		On("CreateScenario", "myorg/myapp", bytes.NewReader([]byte(validAppmap))).
+		On("CreateScenario", "myorg/myapp", (*uint64)(nil), bytes.NewReader([]byte(validAppmap))).
 		Return(&appland.ScenarioResponse{UUID: "uuid"}, nil)
 
 	mockClient.
@@ -135,7 +135,7 @@ func TestUploadForcedTooLargeAppMap(t *testing.T) {
 	api = mockClient
 
 	mockClient.
-		On("CreateScenario", "myorg/myapp", mock.AnythingOfType("*bytes.Reader")).
+		On("CreateScenario", "myorg/myapp", (*uint64)(nil), mock.AnythingOfType("*bytes.Reader")).
 		Return(&appland.ScenarioResponse{UUID: "uuid"}, nil)
 
 	mockClient.
@@ -172,7 +172,7 @@ func TestUploadWithGitMetadata(t *testing.T) {
 
 	mockClient := &MockClient{}
 	mockClient.
-		On("CreateScenario", "myorg/myapp", bytes.NewReader([]byte(validAppmapWithMetadata))).
+		On("CreateScenario", "myorg/myapp", (*uint64)(nil), bytes.NewReader([]byte(validAppmapWithMetadata))).
 		Return(&appland.ScenarioResponse{UUID: "uuid"}, nil)
 
 	mockClient.
@@ -217,7 +217,7 @@ func TestUploadWithBranchOverride(t *testing.T) {
 
 	mockClient := &MockClient{}
 	mockClient.
-		On("CreateScenario", "myorg/myapp", bytes.NewReader([]byte(validAppmapWithBranchOverride))).
+		On("CreateScenario", "myorg/myapp", (*uint64)(nil), bytes.NewReader([]byte(validAppmapWithBranchOverride))).
 		Return(&appland.ScenarioResponse{UUID: "uuid"}, nil)
 
 	branchOverride := "my-branch"

--- a/cmd/upload_test.go
+++ b/cmd/upload_test.go
@@ -45,7 +45,7 @@ func (m *MockClient) CreateMapSet(mapset *appland.MapSet) (*appland.CreateMapSet
 	return resp, args.Error(1)
 }
 
-func (m *MockClient) CreateScenario(app string, mapsetId *uint64, scenarioData io.Reader) (*appland.ScenarioResponse, error) {
+func (m *MockClient) CreateScenario(app string, mapsetId uint64, scenarioData io.Reader) (*appland.ScenarioResponse, error) {
 	args := m.Called(app, mapsetId, scenarioData)
 	resp, _ := args.Get(0).(*appland.ScenarioResponse)
 	return resp, args.Error(1)
@@ -74,7 +74,7 @@ func TestUploadSingleAppMap(t *testing.T) {
 	api = mockClient
 
 	mockClient.
-		On("CreateScenario", "myorg/myapp", (*uint64)(nil), bytes.NewReader([]byte(validAppmap))).
+		On("CreateScenario", "myorg/myapp", (uint64)(0), bytes.NewReader([]byte(validAppmap))).
 		Return(&appland.ScenarioResponse{UUID: "uuid"}, nil)
 
 	mockClient.
@@ -135,7 +135,7 @@ func TestUploadForcedTooLargeAppMap(t *testing.T) {
 	api = mockClient
 
 	mockClient.
-		On("CreateScenario", "myorg/myapp", (*uint64)(nil), mock.AnythingOfType("*bytes.Reader")).
+		On("CreateScenario", "myorg/myapp", (uint64)(0), mock.AnythingOfType("*bytes.Reader")).
 		Return(&appland.ScenarioResponse{UUID: "uuid"}, nil)
 
 	mockClient.
@@ -172,7 +172,7 @@ func TestUploadWithGitMetadata(t *testing.T) {
 
 	mockClient := &MockClient{}
 	mockClient.
-		On("CreateScenario", "myorg/myapp", (*uint64)(nil), bytes.NewReader([]byte(validAppmapWithMetadata))).
+		On("CreateScenario", "myorg/myapp", (uint64)(0), bytes.NewReader([]byte(validAppmapWithMetadata))).
 		Return(&appland.ScenarioResponse{UUID: "uuid"}, nil)
 
 	mockClient.
@@ -217,7 +217,7 @@ func TestUploadWithBranchOverride(t *testing.T) {
 
 	mockClient := &MockClient{}
 	mockClient.
-		On("CreateScenario", "myorg/myapp", (*uint64)(nil), bytes.NewReader([]byte(validAppmapWithBranchOverride))).
+		On("CreateScenario", "myorg/myapp", (uint64)(0), bytes.NewReader([]byte(validAppmapWithBranchOverride))).
 		Return(&appland.ScenarioResponse{UUID: "uuid"}, nil)
 
 	branchOverride := "my-branch"

--- a/internal/appland/client.go
+++ b/internal/appland/client.go
@@ -35,7 +35,7 @@ type Client interface {
 	BuildUrl(paths ...interface{}) string
 	Context() *config.Context
 	CreateMapSet(mapset *MapSet) (*CreateMapSetResponse, error)
-	CreateScenario(org string, mapsetId *uint64, scenarioData io.Reader) (*ScenarioResponse, error)
+	CreateScenario(org string, mapsetId uint64, scenarioData io.Reader) (*ScenarioResponse, error)
 	GetScenario(id int) (*ScenarioResponse, error)
 	DeleteAPIKey() error
 	Login(login string, password string) error
@@ -234,7 +234,7 @@ type message struct {
 	contentType string
 }
 
-func scenarioMessage(scenarioData io.Reader, metadata []byte, mapsetId *uint64) (*message, error) {
+func scenarioMessage(scenarioData io.Reader, metadata []byte, mapsetId uint64) (*message, error) {
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)
 
@@ -248,7 +248,7 @@ func scenarioMessage(scenarioData io.Reader, metadata []byte, mapsetId *uint64) 
 	}
 	p.Write(metadata)
 
-	if mapsetId != nil {
+	if mapsetId > 0 {
 		h = make(textproto.MIMEHeader)
 		h.Set("Content-Type", "application/json")
 		h.Set("Content-Disposition", "inline; name=\"mapset_id\"")
@@ -257,7 +257,7 @@ func scenarioMessage(scenarioData io.Reader, metadata []byte, mapsetId *uint64) 
 		if err != nil {
 			return nil, err
 		}
-		p.Write([]byte(strconv.FormatUint(*mapsetId, 10)))
+		p.Write([]byte(strconv.FormatUint(mapsetId, 10)))
 	}
 
 	h = make(textproto.MIMEHeader)
@@ -283,7 +283,7 @@ func scenarioMessage(scenarioData io.Reader, metadata []byte, mapsetId *uint64) 
 	return &message{buf, ctype}, nil
 }
 
-func (client *clientImpl) CreateScenario(app string, mapsetId *uint64, scenarioData io.Reader) (*ScenarioResponse, error) {
+func (client *clientImpl) CreateScenario(app string, mapsetId uint64, scenarioData io.Reader) (*ScenarioResponse, error) {
 	metadata := []byte(fmt.Sprintf(`{ "app": "%s" }`, app))
 	util.Time("generating multipart")
 	message, err := scenarioMessage(scenarioData, metadata, mapsetId)

--- a/internal/appland/client.go
+++ b/internal/appland/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"os"
+	"strconv"
 
 	"github.com/applandinc/appland-cli/internal/config"
 	"github.com/applandinc/appland-cli/internal/metadata"
@@ -34,7 +35,7 @@ type Client interface {
 	BuildUrl(paths ...interface{}) string
 	Context() *config.Context
 	CreateMapSet(mapset *MapSet) (*CreateMapSetResponse, error)
-	CreateScenario(org string, scenarioData io.Reader) (*ScenarioResponse, error)
+	CreateScenario(org string, mapsetId *uint64, scenarioData io.Reader) (*ScenarioResponse, error)
 	GetScenario(id int) (*ScenarioResponse, error)
 	DeleteAPIKey() error
 	Login(login string, password string) error
@@ -233,7 +234,7 @@ type message struct {
 	contentType string
 }
 
-func scenarioMessage(scenarioData io.Reader, metadata []byte) (*message, error) {
+func scenarioMessage(scenarioData io.Reader, metadata []byte, mapsetId *uint64) (*message, error) {
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)
 
@@ -246,6 +247,18 @@ func scenarioMessage(scenarioData io.Reader, metadata []byte) (*message, error) 
 		return nil, err
 	}
 	p.Write(metadata)
+
+	if mapsetId != nil {
+		h = make(textproto.MIMEHeader)
+		h.Set("Content-Type", "application/json")
+		h.Set("Content-Disposition", "inline; name=\"mapset_id\"")
+
+		p, err := w.CreatePart(h)
+		if err != nil {
+			return nil, err
+		}
+		p.Write([]byte(strconv.FormatUint(*mapsetId, 10)))
+	}
 
 	h = make(textproto.MIMEHeader)
 	h.Set("Content-Type", "application/json")
@@ -270,10 +283,10 @@ func scenarioMessage(scenarioData io.Reader, metadata []byte) (*message, error) 
 	return &message{buf, ctype}, nil
 }
 
-func (client *clientImpl) CreateScenario(app string, scenarioData io.Reader) (*ScenarioResponse, error) {
+func (client *clientImpl) CreateScenario(app string, mapsetId *uint64, scenarioData io.Reader) (*ScenarioResponse, error) {
 	metadata := []byte(fmt.Sprintf(`{ "app": "%s" }`, app))
 	util.Time("generating multipart")
-	message, err := scenarioMessage(scenarioData, metadata)
+	message, err := scenarioMessage(scenarioData, metadata, mapsetId)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/appland/client_test.go
+++ b/internal/appland/client_test.go
@@ -233,8 +233,7 @@ func TestCreateScenario(t *testing.T) {
 		JSON(map[string]string{"uuid": scenarioUUID})
 
 	client := MakeTestClient()
-	var mapsetId uint64 = 123
-	res, err := client.CreateScenario("myapp", &mapsetId, strings.NewReader("{}"))
+	res, err := client.CreateScenario("myapp", 123, strings.NewReader("{}"))
 	if err != nil {
 		fmt.Errorf("Error: %s", err)
 	}
@@ -265,7 +264,7 @@ func TestCreateScenarioNilMapset(t *testing.T) {
 		JSON(map[string]string{"uuid": scenarioUUID})
 
 	client := MakeTestClient()
-	res, err := client.CreateScenario("myapp", nil, strings.NewReader("{}"))
+	res, err := client.CreateScenario("myapp", 0, strings.NewReader("{}"))
 	if err != nil {
 		fmt.Errorf("Error: %s", err)
 	}


### PR DESCRIPTION
Adds an optional `-m/--mapset` flag to upload scenarios to an existing mapset